### PR TITLE
Remove default key mappings and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AddDebugger("o")
 RemoveAllDebuggers()
 ```
 
-It is recommended that you map them in your '.vimrc', for example:
+It is recommended that you map them in your `.vimrc`, for example:
 
 ```VIM
 nmap <Leader>P :call AddDebugger("O")<cr>

--- a/README.md
+++ b/README.md
@@ -28,24 +28,22 @@ it is best to wrap it in single quotes. Also note that by setting
 want to only change one of the default entries, you will have to supply the
 rest of them as well.
 
-`vim-infer-debugger` defines three key mappings by default:
-
-```VIM
-nmap <Leader>P :call AddDebugger("O")<cr>
-nmap <Leader>p :call AddDebugger("o")<cr>
-nmap <Leader>d :call RemoveAllDebuggers()<cr>
-```
-
 ## Configuration
 
-If you wish to remap any of the default mappings, just follow the syntax above
-and assign the appropriate functions to the key binding you would like.
-Furthermore, the following functions are exposed for your use.
+`vim-infer-debugger` exposes the following functions for your use.
 
 ```VIM
 AddDebugger("O")
 AddDebugger("o")
 RemoveAllDebuggers()
+```
+
+It is recommended that you map them in your '.vimrc', for example:
+
+```VIM
+nmap <Leader>P :call AddDebugger("O")<cr>
+nmap <Leader>p :call AddDebugger("o")<cr>
+nmap <Leader>d :call RemoveAllDebuggers()<cr>
 ```
 
 ## Installation

--- a/plugin/debugger.vim
+++ b/plugin/debugger.vim
@@ -21,9 +21,6 @@ function! AddDebugger(direction)
   endif
 endfunction
 
-nmap <Leader>P :call AddDebugger("O")<cr>
-nmap <Leader>p :call AddDebugger("o")<cr>
-
 function! RemoveAllDebuggers()
   let debugger_array = FindDebuggerArray()
 
@@ -34,8 +31,6 @@ function! RemoveAllDebuggers()
     echo NoDebuggerFoundError()
   end
 endfunction
-
-nmap <Leader>d :call RemoveAllDebuggers()<cr>
 
 function! FindDebuggerArray()
   let file_extension = split(expand("%"), "/")[-1]


### PR DESCRIPTION
Removes the default key bindings, instead suggesting in the `README` how to map the keys oneself.

This is out of respects for everyone's own preference in how their keys are mapped and to prevent key mapping conflicts. Most good vim plugins, such as `vim-rspec`, `vim-cargo` and others, don't map keys, but instead suggest sensible defaults in the `README`
In my case, `<leader>d` was conflicting with `YouCompleteMe`, which was overwriting it.
