### PR TITLE
Return empty array instead of "" if we can't find a matching ext.

### DIFF
--- a/plugin/debugger.vim
+++ b/plugin/debugger.vim
@@ -14,7 +14,7 @@ endif
 function! AddDebugger(direction)
   let debugger_array = FindDebuggerArray()
 
-  if debugger_array != ""
+  if debugger_array != []
     execute "normal!" a:direction debugger_array[1]
   else
     echo NoDebuggerFoundError()
@@ -24,7 +24,7 @@ endfunction
 function! RemoveAllDebuggers()
   let debugger_array = FindDebuggerArray()
 
-  if debugger_array != ""
+  if debugger_array != []
     let command = join(["g/", debugger_array[1], "/d"], "")
     execute command
   else
@@ -40,6 +40,8 @@ function! FindDebuggerArray()
       return array
     endif
   endfor
+
+  return []
 endfunction
 
 function! NoDebuggerFoundError()


### PR DESCRIPTION
Resolves the `Cannot compare List with String` error.
