### PR TITLE
Remove unnecessary space before a breakpoint

### DIFF
--- a/plugin/debugger.vim
+++ b/plugin/debugger.vim
@@ -16,7 +16,7 @@ function! AddDebugger(direction)
   let debugger_array = FindDebuggerArray()
 
   if debugger_array != []
-    execute "normal!" a:direction debugger_array[1]
+    execute "normal!" a:direction.debugger_array[1]
   else
     echo NoDebuggerFoundError()
   endif


### PR DESCRIPTION
Hi!
As far as I see in current implementation an extra space appears before a breakpoint statement, because the final command looks like this:

``` vimscript
:normal! O breakpoint
```

I believe it should be like this:

``` vimscript
:normal! Obreakpoint
```
