### PR TITLE
Remove extra space on insertion

### DIFF
--- a/plugin/debugger.vim
+++ b/plugin/debugger.vim
@@ -16,7 +16,7 @@ function! AddDebugger(direction)
   let debugger_array = FindDebuggerArray()
 
   if debugger_array != []
-    execute "normal!" a:direction debugger_array[1]
+    execute "normal!" a:direction.debugger_array[1]
   else
     echo NoDebuggerFoundError()
   endif


### PR DESCRIPTION
I noticed that whenever this script inserted a `debugger` there was a space before the debugger. I have never really written Vimscript but this appears to fix the issue 😬 .
