### PR TITLE
Refactor plugin to use dictionary, allowing user customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ file you're in. It comes with a set of defaults:
         \ }
 ```
 
-In order to define your own debuggers, just overwrite `g:debugger_dictionary` in
-your `.vimrc` Please note that when defining the regex for the file extension,
-it is best to wrap it in single quotes. Also note that by setting
-`g:debugger_dictionary` in your `.vimrc`, you overwrite the entire dictionary. So if you
-want to only change one of the default entries, you will have to supply the
-rest of them as well.
+In order to add your own debuggers, define `g:user_debugger_dictionary` in your `.vimrc`. Your settings will be added to the predefined list, or overwrite existing entries. Please note that when defining the regex for the file extension, it is best to wrap it in single quotes. For example, if you wanted to use byebug instead of pry for Ruby files, you could add the following to your configuration file:
+```VIM
+let g:user_debugger_dictionary = {
+      \ '\.rb': 'byebug',
+      \ }
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -9,25 +9,27 @@ corresponding debuggers, and then selects the correct debugger based on the
 file you're in. It comes with a set of defaults:
 
 ```VIM
-  let g:debugger_array = [['\.rb',             'require "pry"; binding.pry'],
-                         \['\.rake',           'require "pry"; binding.pry'],
-                         \['\.ex$',            'require IEx; IEx.pry'],
-                         \['\.exs',            'require IEx; IEx.pry'],
-                         \['\.erb',            '<% require "pry"; binding.pry %>'],
-                         \['\.haml',           '- require "pry"; binding.pry'],
-                         \['\.eex',            '<% require IEx; IEx.pry %>'],
-                         \['\.coffee$',        'debugger'],
-                         \['\.json\.jbuilder', 'require "pry"; binding.pry'],
-                         \['\.js$',            'debugger;'],
-                         \['\.jsx$',           'debugger;'],
-                         \['\.rs$',            'println!("{:?}", )'],
-                         \['\.py$',            'import pdb; pdb.set_trace()']]
+  let g:debugger_dictionary = {
+        \ '\.rb':             'require "pry"; binding.pry',
+        \ '\.rake':           'require "pry"; binding.pry',
+        \ '\.ex$':            'require IEx; IEx.pry',
+        \ '\.exs':            'require IEx; IEx.pry',
+        \ '\.erb':            '<% require "pry"; binding.pry %>',
+        \ '\.haml':           '- require "pry"; binding.pry',
+        \ '\.eex':            '<%= require IEx; IEx.pry %>',
+        \ '\.coffee$':        'debugger',
+        \ '\.json\.jbuilder': 'require "pry"; binding.pry',
+        \ '\.js$':            'debugger;',
+        \ '\.jsx$':           'debugger;',
+        \ '\.rs$':            'println!("{:?}", );',
+        \ '\.py$':            'import pdb; pdb.set_trace()',
+        \ }
 ```
 
-In order to define your own debuggers, just overwrite `g:debugger_array` in
+In order to define your own debuggers, just overwrite `g:debugger_dictionary` in
 your `.vimrc` Please note that when defining the regex for the file extension,
 it is best to wrap it in single quotes. Also note that by setting
-`g:debugger_array` in your `.vimrc`, you overwrite the entire array. So if you
+`g:debugger_dictionary` in your `.vimrc`, you overwrite the entire dictionary. So if you
 want to only change one of the default entries, you will have to supply the
 rest of them as well.
 

--- a/plugin/debugger.vim
+++ b/plugin/debugger.vim
@@ -1,19 +1,21 @@
-if !exists("g:debugger_dictionary")
-  let g:debugger_dictionary = {
-        \ '\.rb':             'require "pry"; binding.pry',
-        \ '\.rake':           'require "pry"; binding.pry',
-        \ '\.ex$':            'require IEx; IEx.pry',
-        \ '\.exs':            'require IEx; IEx.pry',
-        \ '\.erb':            '<% require "pry"; binding.pry %>',
-        \ '\.haml':           '- require "pry"; binding.pry',
-        \ '\.eex':            '<%= require IEx; IEx.pry %>',
-        \ '\.coffee$':        'debugger',
-        \ '\.json\.jbuilder': 'require "pry"; binding.pry',
-        \ '\.js$':            'debugger;',
-        \ '\.jsx$':           'debugger;',
-        \ '\.rs$':            'println!("{:?}", );',
-        \ '\.py$':            'import pdb; pdb.set_trace()',
-        \ }
+let g:debugger_dictionary = {
+      \ '\.rb':             'require "pry"; binding.pry',
+      \ '\.rake':           'require "pry"; binding.pry',
+      \ '\.ex$':            'require IEx; IEx.pry',
+      \ '\.exs':            'require IEx; IEx.pry',
+      \ '\.erb':            '<% require "pry"; binding.pry %>',
+      \ '\.haml':           '- require "pry"; binding.pry',
+      \ '\.eex':            '<%= require IEx; IEx.pry %>',
+      \ '\.coffee$':        'debugger',
+      \ '\.json\.jbuilder': 'require "pry"; binding.pry',
+      \ '\.js$':            'debugger;',
+      \ '\.jsx$':           'debugger;',
+      \ '\.rs$':            'println!("{:?}", );',
+      \ '\.py$':            'import pdb; pdb.set_trace()',
+      \ }
+
+if exists("g:user_debugger_dictionary")
+  call extend(g:debugger_dictionary, g:user_debugger_dictionary, "force")
 endif
 
 function! AddDebugger(direction)

--- a/plugin/debugger.vim
+++ b/plugin/debugger.vim
@@ -1,50 +1,52 @@
-if !exists("g:debugger_array")
- let g:debugger_array = [['\.rb',             'require "pry"; binding.pry'],
-                        \['\.rake',           'require "pry"; binding.pry'],
-                        \['\.ex$',            'require IEx; IEx.pry'],
-                        \['\.exs',            'require IEx; IEx.pry'],
-                        \['\.erb',            '<% require "pry"; binding.pry %>'],
-                        \['\.haml',           '- require "pry"; binding.pry'],
-                        \['\.eex',            '<%= require IEx; IEx.pry %>'],
-                        \['\.coffee$',        'debugger'],
-                        \['\.json\.jbuilder', 'require "pry"; binding.pry'],
-                        \['\.js$',            'debugger;'],
-                        \['\.jsx$',           'debugger;'],
-                        \['\.rs$',            'println!("{:?}", );'],
-                        \['\.py$',            'import pdb; pdb.set_trace()']]
+if !exists("g:debugger_dictionary")
+  let g:debugger_dictionary = {
+        \ '\.rb':             'require "pry"; binding.pry',
+        \ '\.rake':           'require "pry"; binding.pry',
+        \ '\.ex$':            'require IEx; IEx.pry',
+        \ '\.exs':            'require IEx; IEx.pry',
+        \ '\.erb':            '<% require "pry"; binding.pry %>',
+        \ '\.haml':           '- require "pry"; binding.pry',
+        \ '\.eex':            '<%= require IEx; IEx.pry %>',
+        \ '\.coffee$':        'debugger',
+        \ '\.json\.jbuilder': 'require "pry"; binding.pry',
+        \ '\.js$':            'debugger;',
+        \ '\.jsx$':           'debugger;',
+        \ '\.rs$':            'println!("{:?}", );',
+        \ '\.py$':            'import pdb; pdb.set_trace()',
+        \ }
 endif
 
 function! AddDebugger(direction)
-  let debugger_array = FindDebuggerArray()
+  let debugger_statement = FindDebuggerStatement()
 
-  if debugger_array != []
-    execute "normal!" a:direction.debugger_array[1]
+  if debugger_statement != ""
+    execute "normal!" a:direction.debugger_statement
   else
     echo NoDebuggerFoundError()
   endif
 endfunction
 
 function! RemoveAllDebuggers()
-  let debugger_array = FindDebuggerArray()
+  let debugger_statement = FindDebuggerStatement()
 
-  if debugger_array != []
-    let command = join(["g/", debugger_array[1], "/d"], "")
+  if debugger_statement != ""
+    let command = join(["g/", debugger_statement, "/d"], "")
     execute command
   else
     echo NoDebuggerFoundError()
   end
 endfunction
 
-function! FindDebuggerArray()
-  let file_extension = split(expand("%"), "/")[-1]
+function! FindDebuggerStatement()
+  let current_file_extension = split(expand("%"), "/")[-1]
 
-  for array in g:debugger_array
-    if file_extension =~ array[0]
-      return array
+  for file_extension in keys(g:debugger_dictionary)
+    if current_file_extension =~ file_extension
+      return g:debugger_dictionary[file_extension]
     endif
   endfor
 
-  return []
+  return ""
 endfunction
 
 function! NoDebuggerFoundError()


### PR DESCRIPTION
After a quick weekend crash course on Vimscript, I've got this change made. 😄

I broke this into a couple commits. The first one maintains all of the existing functionality, where the debugger list from a `.vimrc` config will completely overwrite the existing one in the plugin. The difference being that this uses a dictionary, so it is a breaking change.

The next commit looks for a user-provided dictionary called `g:user_debugger_dictionary`, which is then merged into the default one. The `"force"` argument on the `extend()` call overwrites any existing duplicate keys.

I was hoping that the config could be a one-liner, but I realized that `.vimrc` is loaded before plugins, so calls to edit the dictionary threw errors since it isn't yet defined.

This approach follows a convention I've seen in [mattn/emmet-vim](https://github.com/mattn/emmet-vim#adding-custom-snippets) where users can define a `g:user_emmet_settings` variable, which then gets merged in with the plugin defaults, and seemed to be a good fit for this use case.

Of course, I'm open to feedback on variable names or anything else related to these changes.

Cheers!

Closes #18 